### PR TITLE
lifecycle: fix systemd suspend hook issue

### DIFF
--- a/cbc_lifecycle/cbc_lifecycle.c
+++ b/cbc_lifecycle/cbc_lifecycle.c
@@ -341,7 +341,7 @@ void *cbc_heartbeat_loop(void)
 						cbc_heartbeat_rtc, p_size);
 					cbc_rtc_set = 0;
 				}
-				system("echo mem > /sys/power/state");
+				system("systemctl suspend");
 			}
 			state_transit(S_DEFAULT);// for s3 case
 			break;


### PR DESCRIPTION
Internally, systemd will echo a string like "mem" into /sys/power/state,
to trigger the actual system suspend. If any service is wanted by
suspend.target, systemd will hook this service automatically.

lifecycle should not suspend system with "echo mem > /sys/power/state"
directly. It will bypass the systemd and causes suspend hook services not to
work.

Signed-off-by: Bin Yang <bin.yang@intel.com>