### PR TITLE
cbc_thermal: modprobe fuse

### DIFF
--- a/cbc_thermal/README.md
+++ b/cbc_thermal/README.md
@@ -258,5 +258,5 @@ The thermal chart can be find in /run/log/cbc_thermal_chart-*.svg. It shows the 
 The default config has a trip point to reboot system while cbc_env_temp reach 100. We can trigger this trip point manually with debug interface.
 ```
 echo -n 0 > /run/cbc_thermal/auto_update
-echo -n 100 > /run/cbc_thermal/cbc_env_temp
+echo -n 100000 > /run/cbc_thermal/cbc_env_temp
 ```

--- a/cbc_thermal/cbc_thermald_start
+++ b/cbc_thermal/cbc_thermald_start
@@ -5,6 +5,10 @@ if [ ! -e /etc/ioc-cbc-tools/thermal-conf.xml ]; then
 	cp /usr/share/ioc-cbc-tools/thermal-conf.xml /etc/ioc-cbc-tools/thermal-conf.xml
 fi
 
+if [ ! -e /sys/module/fuse ]; then
+    modprobe fuse
+fi
+
 /usr/bin/cbc_thermal &
 sleep 10
 /usr/bin/thermald --no-daemon --ignore-cpuid-check --ignore-default-control --config-file /etc/ioc-cbc-tools/thermal-conf.xml


### PR DESCRIPTION
fuse driver is required by cbc_thermal. Add the check and modprobe
in launch script

Signed-off-by: Bin Yang <bin.yang@intel.com>