### PR TITLE
Add acrn_common.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 T := $(CURDIR)
 OUT_DIR ?= $(CURDIR)/build
 CFLAGS += -fstack-protector-strong -fPIE -fPIC -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
+CFLAGS += -I$(CURDIR)
 LDFLAGS += -z noexecstack -z relro -z now -pie
 export CFLAGS
 export LDFLAGS

--- a/acrn_common.h
+++ b/acrn_common.h
@@ -1,0 +1,20 @@
+/*
+ * common definition
+ *
+ * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file acrn_common.h
+ *
+ * @brief acrn common data structure for hypercall or ioctl
+ */
+
+#ifndef ACRN_COMMON_H
+#define ACRN_COMMON_H
+
+#define MAX_VM_OS_NAME_LEN    32U
+
+#endif /* ACRN_COMMON_H */


### PR DESCRIPTION
The acrn_mngr.h include acrn_common.h, to get the VM name length,
which is defined by acrn hypervisor now.
And acrn_common.h also included lots of headers in acrn-hypervisor
source code, which make it to be hard to port to acrn_common.h to
another project.
So we can add an acrn_common.h for cbc tools mannully.

Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>