### PR TITLE
makefile: add /usr/include/acrn to CFLAGS

### DIFF
--- a/cbc_lifecycle/Makefile
+++ b/cbc_lifecycle/Makefile
@@ -1,6 +1,8 @@
 
 OUT_DIR ?= .
 
+CFLAGS += -I/usr/include/acrn
+
 $(OUT_DIR)/cbc_lifecycle: cbc_lifecycle.c
 	gcc -o $@ $(CFLAGS) $(LDFLAGS) cbc_lifecycle.c -pthread -lacrn-mngr
 


### PR DESCRIPTION
As acrn_mngr.h is including new includes and they are stored in
/usr/include/acrn, then let's add this path to CFLAGS.

related to https://github.com/projectacrn/acrn-hypervisor/issues/3368
fixes intel/ioc-cbc-tools#16